### PR TITLE
fix: resolve BRAVE_SEARCH_API JSON parsing error

### DIFF
--- a/src/graph/nodes.py
+++ b/src/graph/nodes.py
@@ -71,6 +71,18 @@ def background_investigation_node(state: State, config: RunnableConfig):
         background_investigation_results = get_web_search_tool(
             configurable.max_search_results
         ).invoke(query)
+        
+        # Handle potential JSON strings from search engines like BraveSearch
+        if isinstance(background_investigation_results, str):
+            # If it's already a JSON string, try to parse and re-serialize it
+            try:
+                parsed_results = json.loads(background_investigation_results)
+                background_investigation_results = parsed_results
+            except json.JSONDecodeError:
+                # If it's not valid JSON, treat it as plain text
+                logger.warning(f"Search engine returned non-JSON string: {background_investigation_results[:200]}...")
+                background_investigation_results = [{"type": "text", "content": background_investigation_results}]
+    
     return {
         "background_investigation_results": json.dumps(
             background_investigation_results, ensure_ascii=False

--- a/web/src/core/utils/json.ts
+++ b/web/src/core/utils/json.ts
@@ -10,8 +10,21 @@ export function parseJSON<T>(json: string | null | undefined, fallback: T) {
       .replace(/^```json\s*/, "")
       .replace(/^```\s*/, "")
       .replace(/\s*```$/, "");
-    return parse(raw) as T;
-  } catch {
+    
+    // Handle potential double-encoded JSON strings
+    let parsed = parse(raw);
+    if (typeof parsed === 'string') {
+      try {
+        // Try to parse again if the result is a string
+        parsed = parse(parsed);
+      } catch {
+        // If second parse fails, use the original string result
+      }
+    }
+    
+    return parsed as T;
+  } catch (error) {
+    console.warn('Failed to parse JSON:', error, 'Input:', json?.substring(0, 200));
     return fallback;
   }
 }


### PR DESCRIPTION
Fixes #2

Resolves the "parsed json with extra tokens" error when using BRAVE_SEARCH_API.

## Changes
- Handle potential JSON strings from BraveSearch before applying json.dumps()
- Enhance frontend parseJSON to handle double-encoded JSON strings
- Add better error logging for debugging JSON parsing issues

Generated with [Claude Code](https://claude.ai/code)